### PR TITLE
fix: Fix recurrence for tweet events - MEED-3158 - Meeds-io/meeds#1539

### DIFF
--- a/gamification-twitter-services/src/main/java/io/meeds/gamification/twitter/service/TwitterConsumerService.java
+++ b/gamification-twitter-services/src/main/java/io/meeds/gamification/twitter/service/TwitterConsumerService.java
@@ -59,11 +59,11 @@ public interface TwitterConsumerService {
    * Retrieve available tweets in which the account identified by its identifier
    * was mentioned
    *
-   * @param twitterRemoteId Twitter account remote Id
+   * @param twitterAccount {@link TwitterAccount} Twitter account
    * @param lastMentionTweetId last mention tweet Id
    * @param bearerToken Twitter bearer token
    */
-  List<TwitterTrigger> getMentionEvents(long twitterRemoteId, long lastMentionTweetId, String bearerToken);
+  List<TwitterTrigger> getMentionEvents(TwitterAccount twitterAccount, long lastMentionTweetId, String bearerToken);
 
   /**
    * clear remote twitter account entities cache

--- a/gamification-twitter-services/src/main/java/io/meeds/gamification/twitter/service/TwitterTriggerService.java
+++ b/gamification-twitter-services/src/main/java/io/meeds/gamification/twitter/service/TwitterTriggerService.java
@@ -22,9 +22,9 @@ import io.meeds.gamification.twitter.model.TwitterTrigger;
 public interface TwitterTriggerService {
 
   /**
-   * Handle twitter trigger asynchronously
+   * Handle twitter trigger
    *
    * @param twitterTrigger twitter retrieved trigger.
    */
-  void handleTriggerAsync(TwitterTrigger twitterTrigger);
+  void handleTrigger(TwitterTrigger twitterTrigger);
 }

--- a/gamification-twitter-services/src/main/java/io/meeds/gamification/twitter/service/impl/TwitterAccountServiceImpl.java
+++ b/gamification-twitter-services/src/main/java/io/meeds/gamification/twitter/service/impl/TwitterAccountServiceImpl.java
@@ -132,8 +132,9 @@ public class TwitterAccountServiceImpl implements TwitterAccountService {
       twitterAccount.setIdentifier(remoteTwitterAccount.getUsername());
       twitterAccount.setRemoteId(remoteTwitterAccount.getId());
       twitterAccount.setName(remoteTwitterAccount.getName());
+      twitterAccount.setIdentifier(remoteTwitterAccount.getUsername());
       twitterAccount.setWatchedBy(currentUser);
-      List<TwitterTrigger> mentionTriggers = twitterConsumerService.getMentionEvents(remoteTwitterAccount.getId(),
+      List<TwitterTrigger> mentionTriggers = twitterConsumerService.getMentionEvents(twitterAccount,
                                                                                      0L,
                                                                                      getTwitterBearerToken());
       if (CollectionUtils.isNotEmpty(mentionTriggers)) {

--- a/gamification-twitter-services/src/main/java/io/meeds/gamification/twitter/service/impl/TwitterConsumerServiceImpl.java
+++ b/gamification-twitter-services/src/main/java/io/meeds/gamification/twitter/service/impl/TwitterConsumerServiceImpl.java
@@ -51,8 +51,8 @@ public class TwitterConsumerServiceImpl implements TwitterConsumerService {
   }
 
   @Override
-  public List<TwitterTrigger> getMentionEvents(long twitterRemoteId, long lastMentionTweetId, String bearerToken) {
-    return twitterConsumerStorage.getMentionEvents(twitterRemoteId, lastMentionTweetId, bearerToken);
+  public List<TwitterTrigger> getMentionEvents(TwitterAccount twitterAccount, long lastMentionTweetId, String bearerToken) {
+    return twitterConsumerStorage.getMentionEvents(twitterAccount, lastMentionTweetId, bearerToken);
   }
 
   @Override

--- a/gamification-twitter-services/src/main/java/io/meeds/gamification/twitter/service/impl/TwitterTriggerServiceImpl.java
+++ b/gamification-twitter-services/src/main/java/io/meeds/gamification/twitter/service/impl/TwitterTriggerServiceImpl.java
@@ -21,16 +21,12 @@ package io.meeds.gamification.twitter.service.impl;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 import io.meeds.gamification.service.TriggerService;
 import io.meeds.gamification.twitter.model.TwitterTrigger;
 import io.meeds.gamification.twitter.service.TwitterTriggerService;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.eclipse.jetty.util.thread.QueuedThreadPool;
-import org.picocontainer.Startable;
 
 import org.exoplatform.commons.api.persistence.ExoTransactional;
 import org.exoplatform.services.listener.ListenerService;
@@ -43,7 +39,7 @@ import io.meeds.gamification.model.EventDTO;
 import io.meeds.gamification.service.ConnectorService;
 import io.meeds.gamification.service.EventService;
 
-public class TwitterTriggerServiceImpl implements TwitterTriggerService, Startable {
+public class TwitterTriggerServiceImpl implements TwitterTriggerService {
 
   private static final Log       LOG                        = ExoLogger.getLogger(TwitterTriggerServiceImpl.class);
 
@@ -61,8 +57,6 @@ public class TwitterTriggerServiceImpl implements TwitterTriggerService, Startab
 
   private final ListenerService  listenerService;
 
-  private ExecutorService        executorService;
-
   public TwitterTriggerServiceImpl(ListenerService listenerService,
                                    ConnectorService connectorService,
                                    IdentityManager identityManager,
@@ -75,26 +69,8 @@ public class TwitterTriggerServiceImpl implements TwitterTriggerService, Startab
     this.triggerService = triggerService;
   }
 
-  @Override
-  public void start() {
-    QueuedThreadPool threadFactory = new QueuedThreadPool(5, 1, 1);
-    threadFactory.setName("Gamification - Twitter connector");
-    executorService = Executors.newCachedThreadPool(threadFactory);
-  }
-
-  @Override
-  public void stop() {
-    if (executorService != null) {
-      executorService.shutdownNow();
-    }
-  }
-
-  public void handleTriggerAsync(TwitterTrigger twitterTrigger) {
-    executorService.execute(() -> handleTriggerAsyncInternal(twitterTrigger));
-  }
-
   @ExoTransactional
-  public void handleTriggerAsyncInternal(TwitterTrigger twitterTrigger) {
+  public void handleTrigger(TwitterTrigger twitterTrigger) {
     processEvent(twitterTrigger);
   }
 


### PR DESCRIPTION
Before this change, Twitter event recursive configuration does not work, asynchronous mechanisms of sending the event cause this, fix this by adding a delay between sending each event.
Fix considers the reply in a tweet as a new mention that's how the Twitter API works, we should add some processing on our side.