### PR TITLE
fix: Not counting a reply to a tweet as a mentioned event - MEED-3159 - Meeds-io/meeds#1539 (#43)

### DIFF
--- a/gamification-twitter-services/src/main/java/io/meeds/gamification/twitter/service/TwitterConsumerService.java
+++ b/gamification-twitter-services/src/main/java/io/meeds/gamification/twitter/service/TwitterConsumerService.java
@@ -59,11 +59,11 @@ public interface TwitterConsumerService {
    * Retrieve available tweets in which the account identified by its identifier
    * was mentioned
    *
-   * @param twitterRemoteId Twitter account remote Id
+   * @param twitterAccount {@link TwitterAccount} Twitter account
    * @param lastMentionTweetId last mention tweet Id
    * @param bearerToken Twitter bearer token
    */
-  List<TwitterTrigger> getMentionEvents(long twitterRemoteId, long lastMentionTweetId, String bearerToken);
+  List<TwitterTrigger> getMentionEvents(TwitterAccount twitterAccount, long lastMentionTweetId, String bearerToken);
 
   /**
    * clear remote twitter account entities cache

--- a/gamification-twitter-services/src/main/java/io/meeds/gamification/twitter/service/impl/TwitterAccountServiceImpl.java
+++ b/gamification-twitter-services/src/main/java/io/meeds/gamification/twitter/service/impl/TwitterAccountServiceImpl.java
@@ -142,8 +142,9 @@ public class TwitterAccountServiceImpl implements TwitterAccountService {
       twitterAccount.setIdentifier(remoteTwitterAccount.getUsername());
       twitterAccount.setRemoteId(remoteTwitterAccount.getId());
       twitterAccount.setName(remoteTwitterAccount.getName());
+      twitterAccount.setIdentifier(remoteTwitterAccount.getUsername());
       twitterAccount.setWatchedBy(currentUser);
-      List<TwitterTrigger> mentionTriggers = twitterConsumerService.getMentionEvents(remoteTwitterAccount.getId(),
+      List<TwitterTrigger> mentionTriggers = twitterConsumerService.getMentionEvents(twitterAccount,
                                                                                      0L,
                                                                                      getTwitterBearerToken());
       if (CollectionUtils.isNotEmpty(mentionTriggers)) {

--- a/gamification-twitter-services/src/main/java/io/meeds/gamification/twitter/service/impl/TwitterConsumerServiceImpl.java
+++ b/gamification-twitter-services/src/main/java/io/meeds/gamification/twitter/service/impl/TwitterConsumerServiceImpl.java
@@ -51,8 +51,8 @@ public class TwitterConsumerServiceImpl implements TwitterConsumerService {
   }
 
   @Override
-  public List<TwitterTrigger> getMentionEvents(long twitterRemoteId, long lastMentionTweetId, String bearerToken) {
-    return twitterConsumerStorage.getMentionEvents(twitterRemoteId, lastMentionTweetId, bearerToken);
+  public List<TwitterTrigger> getMentionEvents(TwitterAccount twitterAccount, long lastMentionTweetId, String bearerToken) {
+    return twitterConsumerStorage.getMentionEvents(twitterAccount, lastMentionTweetId, bearerToken);
   }
 
   @Override

--- a/gamification-twitter-services/src/main/resources/conf/portal/configuration.xml
+++ b/gamification-twitter-services/src/main/resources/conf/portal/configuration.xml
@@ -119,7 +119,7 @@
           <description>Configuration to manage the periodic updating of twitter account events</description>
           <property name="jobName" value="TwitterAccountRemoteUpdate"/>
           <property name="groupName" value="Gamification"/>
-          <property name="job" value="io.meeds.gamification.twitter.scheduled.TwitterAccountRemoteUpdate"/>
+          <property name="job" value="io.meeds.gamification.twitter.scheduled.TwitterAccountRemoteUpdateJob"/>
           <property name="expression" value="${io.meeds.gamification.TwitterAccountRemoteUpdate.expression:0 */15 * * * ?}"/><!-- Every 15 minutes -->
         </properties-param>
       </init-params>


### PR DESCRIPTION
Fix considers the reply in a tweet as a new mention that's how the Twitter API works, we should add some processing on our side.

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
