### PR TITLE
fix: Twitter RT and Likes events do not work when created in a closed space - MEED-3323 - Meeds-io/MIPs#105

### DIFF
--- a/gamification-twitter-services/src/main/java/io/meeds/gamification/twitter/listener/RuleUpdateTwitterListener.java
+++ b/gamification-twitter-services/src/main/java/io/meeds/gamification/twitter/listener/RuleUpdateTwitterListener.java
@@ -53,6 +53,7 @@ public class RuleUpdateTwitterListener extends Listener<RuleDTO, String> {
   public void onEvent(Event<RuleDTO, String> event) {
     RuleFilter ruleFilter = new RuleFilter();
     ruleFilter.setEventType(CONNECTOR_NAME);
+    ruleFilter.setAllSpaces(true);
     List<RuleDTO> rules = ruleService.getRules(ruleFilter, 0, -1);
 
     List<String> watchedTweets = rules.stream()


### PR DESCRIPTION
Before this change, Twitter RT and Likes events did not work when created in a closed space