### PR TITLE
fix: Remove ended twitter event from watched tweet - MEED-3398 - Meeds-io/MIPs#105 (#65)

### DIFF
--- a/gamification-twitter-services/src/main/java/io/meeds/gamification/twitter/listener/RuleUpdateTwitterListener.java
+++ b/gamification-twitter-services/src/main/java/io/meeds/gamification/twitter/listener/RuleUpdateTwitterListener.java
@@ -18,6 +18,7 @@
  */
 package io.meeds.gamification.twitter.listener;
 
+import io.meeds.gamification.constant.DateFilterType;
 import io.meeds.gamification.constant.EntityStatusType;
 import io.meeds.gamification.model.filter.RuleFilter;
 import io.meeds.gamification.service.RuleService;
@@ -55,6 +56,7 @@ public class RuleUpdateTwitterListener extends Listener<RuleDTO, String> {
     RuleFilter ruleFilter = new RuleFilter();
     ruleFilter.setEventType(CONNECTOR_NAME);
     ruleFilter.setStatus(EntityStatusType.ENABLED);
+    ruleFilter.setDateFilterType(DateFilterType.ACTIVE);
     ruleFilter.setAllSpaces(true);
     List<RuleDTO> rules = ruleService.getRules(ruleFilter, 0, -1);
 


### PR DESCRIPTION
Before this change, ended Twitter events remained watched