### PR TITLE
fix: Avoid using v-app in Vue components not main DOM of an app - MEED-7094 - Meeds-io/MIPs#144

### DIFF
--- a/gamification-twitter-webapp/src/main/webapp/vue-app/connectorEventExtensions/components/TwitterEvent.vue
+++ b/gamification-twitter-webapp/src/main/webapp/vue-app/connectorEventExtensions/components/TwitterEvent.vue
@@ -17,7 +17,7 @@
  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 -->
 <template>
-  <v-app>
+  <div>
     <twitter-connector-event-form
       v-if="isEditing"
       :trigger="trigger"
@@ -26,7 +26,7 @@
       v-else
       :trigger="trigger"
       :properties="properties" />
-  </v-app>
+  </div>
 </template>
 <script>
 export default {

--- a/gamification-twitter-webapp/src/main/webapp/vue-app/connectorEventExtensions/components/TwitterEventForm.vue
+++ b/gamification-twitter-webapp/src/main/webapp/vue-app/connectorEventExtensions/components/TwitterEventForm.vue
@@ -17,7 +17,7 @@
  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 -->
 <template>
-  <v-app>
+  <div>
     <template v-if="isTriggerForAccount">
       <v-card-text class="px-0 dark-grey-color font-weight-bold">
         {{ $t('gamification.event.form.account') }}
@@ -58,7 +58,7 @@
         <span class="error--text">{{ $t('gamification.event.detail.invalidLink.error') }}</span>
       </v-list-item-action-text>
     </template>
-  </v-app>
+  </div>
 </template>
 
 <script>

--- a/gamification-twitter-webapp/src/main/webapp/vue-app/twitterAdminConnectorExtension/components/TwitterAdminConnectorItem.vue
+++ b/gamification-twitter-webapp/src/main/webapp/vue-app/twitterAdminConnectorExtension/components/TwitterAdminConnectorItem.vue
@@ -17,7 +17,7 @@ along with this program; if not, write to the Free Software Foundation,
 Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 -->
 <template>
-  <v-app>
+  <div>
     <template v-if="!displayAccountDetail">
       <div class="px-4 py-2 py-sm-5 d-flex align-center">
         <v-tooltip :disabled="$root.isMobile" bottom>
@@ -117,7 +117,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       :ok-label="$t('confirm.yes')"
       :cancel-label="$t('confirm.no')"
       @ok="deleteSettings" />
-  </v-app>
+  </div>
 </template>
 
 <script>


### PR DESCRIPTION
Prior to this change, the v-app was used in Vue components injected via extensionRegistry. This change will change it to simply use a simple div.