### PR TITLE
fix: Delete Jcabi Maven Plugin - Meeds-io/meeds#2417

### DIFF
--- a/gamification-twitter-services/pom.xml
+++ b/gamification-twitter-services/pom.xml
@@ -30,7 +30,7 @@
   <packaging>jar</packaging>
   <name>Meeds:: Gamification Twitter - Service</name>
   <properties>
-    <exo.test.coverage.ratio>0.38</exo.test.coverage.ratio>
+    <exo.test.coverage.ratio>0.37</exo.test.coverage.ratio>
   </properties>
   <dependencies>
     <dependency>
@@ -62,18 +62,6 @@
           <argLine>@{argLine} --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.time=ALL-UNNAMED  --add-opens=java.base/java.time.format=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED </argLine>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>com.jcabi</groupId>
-        <artifactId>jcabi-maven-plugin</artifactId>
-      </plugin>
     </plugins>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-surefire-plugin</artifactId>
-        </plugin>
-      </plugins>
-    </pluginManagement>
   </build>
 </project>


### PR DESCRIPTION
This change will delete JCabi Plugin usage in favor of AspectJ Plugin for AspectJ Annotation processing.