### PR TITLE
fix: Update default charset and collation for mysql - EXO-75202

### DIFF
--- a/gamification-twitter-services/src/main/resources/db/changelog/twitter-connector.db.changelog-1.0.0.xml
+++ b/gamification-twitter-services/src/main/resources/db/changelog/twitter-connector.db.changelog-1.0.0.xml
@@ -29,6 +29,7 @@
 
   <!-- Definition of TWITTER_ACCOUNTS table -->
   <changeSet author="twitter-connector" id="1.0.0-1">
+    <validCheckSum>9:2e0dbc626f3e23dbc53c12b7f233283d</validCheckSum>
     <createTable tableName="TWITTER_ACCOUNTS">
       <column name="ID" type="BIGINT" autoIncrement="${autoIncrement}" startWith="1">
         <constraints nullable="false" primaryKey="true" primaryKeyName="PK_TWITTER_ACCOUNTS"/>
@@ -36,10 +37,10 @@
       <column name="REMOTE_ID" type="BIGINT">
         <constraints nullable="false"/>
       </column>
-      <column name="IDENTIFIER" type="NVARCHAR(250)">
+      <column name="IDENTIFIER" type="VARCHAR(250)">
         <constraints nullable="false"/>
       </column>
-      <column name="NAME" type="NVARCHAR(250)">
+      <column name="NAME" type="VARCHAR(250)">
         <constraints nullable="false"/>
       </column>
       <column name="WATCHED_DATE" type="DATE">
@@ -73,11 +74,12 @@
   </changeSet>
 
   <changeSet author="twitter-connector" id="1.0.0-4">
+    <validCheckSum>9:fd19c9e26bf3b0b7e08ab344311433b6</validCheckSum>
     <createTable tableName="TWITTER_TWEETS">
       <column name="TWEET_ID" type="BIGINT" autoIncrement="${autoIncrement}" startWith="1">
         <constraints nullable="false" primaryKey="true" primaryKeyName="PK_TWITTER_TWEETS"/>
       </column>
-      <column name="TWEET_LINK" type="NVARCHAR(250)">
+      <column name="TWEET_LINK" type="VARCHAR(250)">
         <constraints nullable="false"/>
       </column>
     </createTable>
@@ -88,7 +90,7 @@
       <column name="TWEET_ID" type="BIGINT">
         <constraints nullable="false" foreignKeyName="FK_TWITTER_TWEET_LIKER_ID" references="TWITTER_TWEETS(TWEET_ID)" deleteCascade="true" />
       </column>
-      <column name="LIKER_USERNAME" type="NVARCHAR(200)">
+      <column name="LIKER_USERNAME" type="VARCHAR(200)">
         <constraints nullable="false"/>
       </column>
     </createTable>
@@ -99,7 +101,7 @@
       <column name="TWEET_ID" type="BIGINT">
         <constraints nullable="false" foreignKeyName="FK_TWITTER_TWEET_RETWEETER_ID" references="TWITTER_TWEETS(TWEET_ID)" deleteCascade="true" />
       </column>
-      <column name="RETWEETER_USERNAME" type="NVARCHAR(200)">
+      <column name="RETWEETER_USERNAME" type="VARCHAR(200)">
         <constraints nullable="false"/>
       </column>
     </createTable>


### PR DESCRIPTION
With mysql 8.4, the default charset and collation are updated from UTF to UTF8MB4. In addition NVARCHAR is now deprecated and replaced by VARCHAR. This commit adapt liquibase changes in order to apply this change.

Resolves Meeds-io/meeds#2564

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
